### PR TITLE
add option to blacklist msg from the searched msg

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -143,15 +143,26 @@ local function SearchMessage(msg, from, source)
     local fstart, fend;
     for _, data in pairs(CChatNotifier_data) do
         if data.active then
+            local black = false
             for _, search in ipairs(data.words) do
-                fstart, fend = string.find(msglow, search);
-                if fstart ~= nil then
-                    local nameNoDash = RemoveServerDash(from);
-                    if nameNoDash == playerName then
+                if (search:sub(1,1) == '-') then
+                    fstart, fend = string.find(msglow, search:sub(2));
+                    if fstart ~= nil then
+                        black = true
+                    end
+                end
+            end
+            if (not black) then
+                for _, search in ipairs(data.words) do
+                    fstart, fend = string.find(msglow, search);
+                    if fstart ~= nil then
+                        local nameNoDash = RemoveServerDash(from);
+                        if nameNoDash == playerName then
+                            return;
+                        end
+                        _addon:PostNotification(_addon:FormNotifyMsg(search, source, from, msg, fstart, fend), CChatNotifier_settings.chatFrame);
                         return;
                     end
-                    _addon:PostNotification(_addon:FormNotifyMsg(search, source, from, msg, fstart, fend), CChatNotifier_settings.chatFrame);
-                    return;
                 end
             end
         end


### PR DESCRIPTION
Hi, I dug into this addon a bit and didn't find to way to remove some message from what has been searched out. For example,  there are many flight companies posting message:

```
[5][Someone]: ★★★★【stsm后門3g】★★★★【stsm后門3g】★★★★【斯坦索姆后門3g】★★★★【stsm后門3g】★★★★【stsm后門3g】★★★★【斯坦索姆后門3g】★★★★
[5][Someone]: ★★★★【stsm后門3g】★★★★【stsm后門3g】★★★★【斯坦索姆后門3g】★★★★【stsm后門3g】★★★★【stsm后門3g】★★★★【斯坦索姆后門3g】★★★★
[5][Someone]: ★★★★【stsm后門3g】★★★★【stsm后門3g】★★★★【斯坦索姆后門3g】★★★★【stsm后門3g】★★★★【stsm后門3g】★★★★【斯坦索姆后門3g】★★★★
```

If I want to go to strathome and search the keyword `STSM`, these rubbish messages will be printed.

So I've had an option to remove some message by keywords `STSM,-3G` from what has been searched out. The **minus** indicates the keyword you don't want to see.

